### PR TITLE
Line area graph tool tip style and logic fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "litmus-ui",
   "license": "Apache-2.0",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "description": "Component Library for LitmusChaos",
   "author": "LitmusChaos Authors",

--- a/src/lab/Graphs/LegendTable/index.ts
+++ b/src/lab/Graphs/LegendTable/index.ts
@@ -1,2 +1,2 @@
-export { LegendData } from "./base";
+export type { LegendData } from "./base";
 export * from "./LegendTable";

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -533,6 +533,7 @@ const ComputationGraph: React.FC<GraphProps> = ({
       style={{
         width,
         height: height + legendTableHeight,
+        position: "relative",
       }}
     >
       <svg width={width} height={height}>
@@ -599,28 +600,31 @@ const ComputationGraph: React.FC<GraphProps> = ({
               className={classes.tooltipLine}
             />
           )}
-          {showTips && tooltipData && toolTipPointLength >= 1 && (
-            <g>
-              <circle
-                cx={dateScale(getDateNum(tooltipData[0].data))}
-                cy={valueScale(getValueNum(tooltipData[0].data))}
-                r={5}
-                fill={palette.graph.toolTip}
-                fillOpacity={1}
-                stroke={palette.text.primary}
-                strokeOpacity={1}
-                strokeWidth={2}
-                pointerEvents="none"
-              />
-            </g>
-          )}
+          {showTips &&
+            tooltipData &&
+            toolTipPointLength >= 1 &&
+            tooltipData[0] && (
+              <g>
+                <circle
+                  cx={dateScale(getDateNum(tooltipData[0].data))}
+                  cy={valueScale(getValueNum(tooltipData[0].data))}
+                  r={5}
+                  fill={palette.graph.toolTip}
+                  fillOpacity={1}
+                  stroke={palette.text.primary}
+                  strokeOpacity={1}
+                  strokeWidth={2}
+                  pointerEvents="none"
+                />
+              </g>
+            )}
         </PlotLineAreaGraph>
       </svg>
-      {tooltipData && tooltipData[0] && (
+      {tooltipData && showTips && tooltipData[0] && (
         <div>
           <Tooltip
-            top={height}
-            left={tooltipLeft}
+            top={yMax}
+            left={tooltipLeft - margin.left}
             className={classes.tooltipDateStyles}
           >
             <div
@@ -632,7 +636,7 @@ const ComputationGraph: React.FC<GraphProps> = ({
             </div>
           </Tooltip>
           <Tooltip
-            top={tooltipTop + margin.top}
+            top={tooltipTop}
             left={tooltipLeft + margin.left}
             className={classes.tooltipMetric}
           >

--- a/src/lab/Graphs/LineAreaGraph/PlotLineAreaGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/PlotLineAreaGraph.tsx
@@ -46,7 +46,7 @@ const intToString = (value: number, unit: string) => {
   numValue = shortValue.toString();
 
   if (shortValue % 1 !== 0) {
-    numValue = shortValue.toFixed(1);
+    numValue = shortValue.toFixed(2);
   }
   return `${numValue}${suffixes[suffixNum]} ${unit}`;
 };

--- a/src/lab/Graphs/LineAreaGraph/PlotLineAreaGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/PlotLineAreaGraph.tsx
@@ -113,7 +113,8 @@ const PlotLineAreaGraph: React.FC<AreaChartProps> = ({
     lineHeight: "12px",
   };
   const axisLeftTickLabelProps = {
-    dy: "0.5em",
+    dy: "0.3rem",
+    dx: "-0.3rem",
     fontFamily: "Ubuntu",
     fontWeight: 400,
     fontSize: "10px",

--- a/src/lab/Graphs/LineAreaGraph/index.ts
+++ b/src/lab/Graphs/LineAreaGraph/index.ts
@@ -1,2 +1,2 @@
-export { DateValue, GraphMetric } from "./base";
+export type { DateValue, GraphMetric } from "./base";
 export * from "./LineAreaGraph";

--- a/src/lab/Graphs/LineAreaGraph/styles.ts
+++ b/src/lab/Graphs/LineAreaGraph/styles.ts
@@ -74,6 +74,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     pointerEvents: "none",
   },
   tooltipMetric: {
+    zIndex: 3,
     marginTop: "1rem",
     marginLeft: "3rem",
     padding: "0.5rem",

--- a/src/lab/Graphs/RadialChart/index.ts
+++ b/src/lab/Graphs/RadialChart/index.ts
@@ -1,2 +1,2 @@
-export { RadialChartMetric } from "./base";
+export type { RadialChartMetric } from "./base";
 export * from "./RadialChart";


### PR DESCRIPTION
one edge case logic for `showTips={false}` has been fixed along with other styling fix and export issue