### PR TITLE
Sub data, tooltips 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "litmus-ui",
   "license": "Apache-2.0",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "description": "Component Library for LitmusChaos",
   "author": "LitmusChaos Authors",

--- a/src/lab/Graphs/LegendTable/style.ts
+++ b/src/lab/Graphs/LegendTable/style.ts
@@ -7,8 +7,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: "100%",
     backgroundColor: theme.palette.background.paper,
     overflowY: "auto",
-    boxShadow: `inset 0px -30px 20px -20px ${theme.palette.text.secondary}`,
-
     "&::-webkit-scrollbar": {
       width: "3px",
       height: "3px",

--- a/src/lab/Graphs/LegendTable/style.ts
+++ b/src/lab/Graphs/LegendTable/style.ts
@@ -7,6 +7,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: "100%",
     backgroundColor: theme.palette.background.paper,
     overflowY: "auto",
+    boxShadow: `inset 0px -30px 20px -20px ${theme.palette.text.secondary}`,
+
     "&::-webkit-scrollbar": {
       width: "3px",
       height: "3px",

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -441,11 +441,38 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                   baseColor: eventSeries[j].baseColor,
                 };
                 k++;
+                let startSingleEvent = indexer;
+                let endSingleEvent = indexer;
+
+                while (
+                  (eventSeries[j].data[startSingleEvent].value === "True" ||
+                    eventSeries[j].data[startSingleEvent].value === "End") &&
+                  startSingleEvent > 0
+                ) {
+                  startSingleEvent--;
+                }
+                while (
+                  (eventSeries[j].data[endSingleEvent].value === "True" ||
+                    eventSeries[j].data[endSingleEvent].value === "Start") &&
+                  endSingleEvent < eventSeries[j].data.length
+                ) {
+                  endSingleEvent++;
+                }
+
+                console.log("d1 start:end", startSingleEvent, endSingleEvent);
+
                 if (eventSeries[j].subData) {
-                  eventSeries[j].subData?.forEach((elem) => {
-                    eventTableData[k++] = {
-                      data: [elem.subDataName, elem.value],
-                    };
+                  eventSeries[j].subData?.forEach((singleSubData) => {
+                    if (
+                      singleSubData.date >=
+                        eventSeries[j].data[startSingleEvent].date &&
+                      singleSubData.date <=
+                        eventSeries[j].data[endSingleEvent].date
+                    ) {
+                      eventTableData[k++] = {
+                        data: [singleSubData.subDataName, singleSubData.value],
+                      };
+                    }
                   });
                 }
               }
@@ -476,11 +503,37 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                   baseColor: eventSeries[j].baseColor,
                 };
                 k++;
+
+                let startSingleEvent = indexer;
+                let endSingleEvent = indexer;
+
+                while (
+                  (eventSeries[j].data[startSingleEvent].value === "True" ||
+                    eventSeries[j].data[startSingleEvent].value === "End") &&
+                  startSingleEvent > 0
+                ) {
+                  startSingleEvent--;
+                }
+                while (
+                  (eventSeries[j].data[endSingleEvent].value === "True" ||
+                    eventSeries[j].data[startSingleEvent].value === "Start") &&
+                  endSingleEvent < eventSeries[j].data.length
+                ) {
+                  endSingleEvent++;
+                }
+
                 if (eventSeries[j].subData) {
-                  eventSeries[j].subData?.forEach((elem) => {
-                    eventTableData[k++] = {
-                      data: [elem.subDataName, elem.value],
-                    };
+                  eventSeries[j].subData?.forEach((singleSubData) => {
+                    if (
+                      singleSubData.date >=
+                        eventSeries[j].data[startSingleEvent].date &&
+                      singleSubData.date <=
+                        eventSeries[j].data[endSingleEvent].date
+                    ) {
+                      eventTableData[k++] = {
+                        data: [singleSubData.subDataName, singleSubData.value],
+                      };
+                    }
                   });
                 }
               }
@@ -626,8 +679,6 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
     setfilteredOpenSeries(openSeries);
     setfilteredEventSeries(eventSeries);
   }
-
-  console.log(containerBounds.left);
 
   return (
     <div

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -7,8 +7,9 @@ import {
   localPoint,
   scaleLinear,
   scaleTime,
-  Tooltip,
+  TooltipWithBounds,
   useTooltip,
+  useTooltipInPortal,
 } from "@visx/visx";
 import { bisector, extent, max, min } from "d3-array";
 import dayjs from "dayjs";
@@ -260,7 +261,11 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
       }),
     [yMax, filteredClosedSeries, filteredOpenSeries]
   );
-
+  // Tooltip bounds detection
+  const { containerRef, containerBounds } = useTooltipInPortal({
+    scroll: true,
+    detectBounds: true,
+  });
   //  ToolTip Data
   const {
     showTooltip,
@@ -393,7 +398,6 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         const eventToolTip: Array<ToolTipDateValue> = [];
         eventTableData = eventTableData.splice(0);
         let k = 0;
-        console.log("Pointer Data", pointerDataSelection);
         if (eventSeries) {
           for (j = 0; j < eventSeries.length; j++) {
             indexer = bisectDate(eventSeries[j].data, x0, 1);
@@ -472,6 +476,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
             }
           }
         }
+        console.log(pointerDataSelection);
 
         pointerDataSelection = pointerDataSelection.slice(0, i);
         eventTableData = eventTableData.slice(0, k);
@@ -485,9 +490,9 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
       showTooltip({
         tooltipData: pointerDataSelection,
         tooltipLeft:
-          pointerDataSelection[0] && pointerDataSelection[0].data
+          (pointerDataSelection[0] && pointerDataSelection[0].data
             ? dateScale(getDateNum(pointerDataSelection[0].data))
-            : 0,
+            : dateScale(xMax)) - containerBounds.left,
         tooltipTop:
           pointerDataSelection[0] && pointerDataSelection[0].data
             ? valueScale(getValueNum(pointerDataSelection[0].data))
@@ -604,6 +609,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
 
   return (
     <div
+      ref={containerRef}
       onMouseLeave={() => hideTooltip()}
       style={{
         width,
@@ -697,7 +703,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
       </svg>
       {tooltipData && showTips && tooltipData[0] && (
         <div>
-          <Tooltip
+          <TooltipWithBounds
             top={yMax}
             left={tooltipLeft}
             className={classes.tooltipDateStyles}
@@ -707,10 +713,10 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                 new Date(getDateNum(tooltipData[0].data))
               ).format(toolTiptimeFormat)}`}</span>
             </div>
-          </Tooltip>
-          <Tooltip
+          </TooltipWithBounds>
+          <TooltipWithBounds
             top={tooltipTop}
-            left={tooltipLeft + margin.left}
+            left={tooltipLeft + 60}
             className={classes.tooltipMetric}
           >
             {tooltipData.map((linedata) => (
@@ -729,7 +735,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                 </div>
               </div>
             ))}
-          </Tooltip>
+          </TooltipWithBounds>
         </div>
       )}
       {showLegendTable && showEventTable && (

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -7,6 +7,7 @@ import {
   localPoint,
   scaleLinear,
   scaleTime,
+  Tooltip,
   TooltipWithBounds,
   useTooltip,
   useTooltipInPortal,
@@ -270,7 +271,6 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
   const {
     showTooltip,
     hideTooltip,
-
     tooltipData,
     tooltipLeft = 0,
     tooltipTop = 0,
@@ -476,8 +476,6 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
             }
           }
         }
-        console.log(pointerDataSelection);
-
         pointerDataSelection = pointerDataSelection.slice(0, i);
         eventTableData = eventTableData.slice(0, k);
         // Passing hyphen if eventTableData data is empty
@@ -492,13 +490,17 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         tooltipLeft:
           (pointerDataSelection[0] && pointerDataSelection[0].data
             ? dateScale(getDateNum(pointerDataSelection[0].data))
-            : dateScale(xMax)) - containerBounds.left,
+            : dateScale(xMax)) -
+          containerBounds.left +
+          margin.left -
+          margin.right,
         tooltipTop:
           pointerDataSelection[0] && pointerDataSelection[0].data
             ? valueScale(getValueNum(pointerDataSelection[0].data))
             : 0,
       });
     },
+
     [
       showTips,
       width,
@@ -607,6 +609,8 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
     setfilteredEventSeries(eventSeries);
   }
 
+  console.log(containerBounds.left);
+
   return (
     <div
       ref={containerRef}
@@ -703,7 +707,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
       </svg>
       {tooltipData && showTips && tooltipData[0] && (
         <div>
-          <TooltipWithBounds
+          <Tooltip
             top={yMax}
             left={tooltipLeft}
             className={classes.tooltipDateStyles}
@@ -713,10 +717,10 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                 new Date(getDateNum(tooltipData[0].data))
               ).format(toolTiptimeFormat)}`}</span>
             </div>
-          </TooltipWithBounds>
+          </Tooltip>
           <TooltipWithBounds
             top={tooltipTop}
-            left={tooltipLeft + 60}
+            left={tooltipLeft}
             className={classes.tooltipMetric}
           >
             {tooltipData.map((linedata) => (

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -441,6 +441,9 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                   baseColor: eventSeries[j].baseColor,
                 };
                 k++;
+                // For a singleEvent where the user is hovering,
+                // here we are trying to get to the start and end point
+                // of that event
                 let startSingleEvent = indexer;
                 let endSingleEvent = indexer;
 
@@ -459,10 +462,10 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                   endSingleEvent++;
                 }
 
-                console.log("d1 start:end", startSingleEvent, endSingleEvent);
-
                 if (eventSeries[j].subData) {
                   eventSeries[j].subData?.forEach((singleSubData) => {
+                    // Checking if the timeStamp of the subData lands
+                    // within the start and end of singleEvent the user is hovering
                     if (
                       singleSubData.date >=
                         eventSeries[j].data[startSingleEvent].date &&
@@ -495,9 +498,6 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
                 pointerDataSelection[i] = eventToolTip[j];
                 i++;
 
-                // Selection of the sub-data for the
-                // subData Table from the eventSeries
-                // on which the user is hovering
                 eventTableData[k] = {
                   data: [eventSeries[j].metricName],
                   baseColor: eventSeries[j].baseColor,

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -393,6 +393,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         const eventToolTip: Array<ToolTipDateValue> = [];
         eventTableData = eventTableData.splice(0);
         let k = 0;
+        console.log("Pointer Data", pointerDataSelection);
         if (eventSeries) {
           for (j = 0; j < eventSeries.length; j++) {
             indexer = bisectDate(eventSeries[j].data, x0, 1);
@@ -400,9 +401,10 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
             dd1 = eventSeries[j].data[indexer];
             if (
               dd1 &&
-              (toolTipPointLength - 1 < 0 ||
-                dd1.date ===
-                  pointerDataSelection[toolTipPointLength - 1].data.date)
+              ((toolTipPointLength === 0 && dd1.date >= x0.valueOf()) ||
+                (toolTipPointLength > 0 &&
+                  dd1.date ===
+                    pointerDataSelection[toolTipPointLength - 1].data.date))
             ) {
               eventToolTip[j] = {
                 metricName: eventSeries[j].metricName,
@@ -434,9 +436,10 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
               }
             } else if (
               dd0 &&
-              (toolTipPointLength - 1 < 0 ||
-                dd0.date ===
-                  pointerDataSelection[toolTipPointLength - 1].data.date)
+              ((toolTipPointLength === 0 && dd0.date >= x0.valueOf()) ||
+                (toolTipPointLength > 0 &&
+                  dd0.date ===
+                    pointerDataSelection[toolTipPointLength - 1].data.date))
             ) {
               eventToolTip[j] = {
                 metricName: eventSeries[j].metricName,

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -12,61 +12,33 @@ import {
   useTooltip,
   useTooltipInPortal,
 } from "@visx/visx";
-import { bisector, extent, max, min } from "d3-array";
+import { extent, max, min } from "d3-array";
 import dayjs from "dayjs";
 import React, { useCallback, useMemo, useState } from "react";
 import { LegendData } from "../LegendTable";
 import { LegendTable } from "../LegendTable/LegendTable";
-import { DateValue, LineAreaGraphChildProps, ToolTip } from "./base";
+import {
+  DateValue,
+  LineAreaGraphChildProps,
+  TooltipData,
+  ToolTipDateValue,
+} from "./base";
 import { PlotLineAreaGraph } from "./PlotLineAreaGraph";
 import { useStyles } from "./styles";
+import {
+  bisectDate,
+  bisectorValue,
+  getDateNum,
+  getValueNum,
+  getValueStr,
+} from "./utils";
 
-type ToolTipDateValue = ToolTip<DateValue>;
-type TooltipData = Array<ToolTipDateValue>;
 let dd1: DateValue;
 let dd0: DateValue;
 let i: number;
 let j: number;
 let indexer: number;
 let toolTipPointLength: number;
-
-// Accessor functions
-const getDateNum = (d: DateValue) => {
-  if (d) {
-    if (typeof d.date === "number") {
-      return new Date(d.date);
-    } else return new Date(parseInt(d.date, 10));
-  } else {
-    return new Date(0);
-  }
-};
-
-const getValueNum = (d: DateValue) => {
-  if (d) {
-    if (typeof d.value === "number") {
-      return d.value;
-    } else return parseInt(d.value, 10);
-  } else {
-    return NaN;
-  }
-};
-
-const getValueStr = (d: DateValue) => {
-  if (d) {
-    if (typeof d.value === "number") {
-      return d.value.toFixed(2).toString();
-    } else return d.value;
-  } else {
-    return "";
-  }
-};
-
-// Bisectors
-const bisectDate = bisector<DateValue, Date>((d) => new Date(getDateNum(d)))
-  .left;
-const bisectorValue = bisector<ToolTipDateValue, number>((d) =>
-  getValueNum(d.data)
-).left;
 
 const chartSeparation = 10;
 let legenTablePointerData: Array<ToolTipDateValue>;

--- a/src/lab/Graphs/LineAreaGraph/LineAreaGraph.stories.mdx
+++ b/src/lab/Graphs/LineAreaGraph/LineAreaGraph.stories.mdx
@@ -14,20 +14,23 @@ in form of lines, area-closed under the graph and events.
   <Story
     name="Default"
     args={{
-      legendTableHeight: 80,
+      legendTableHeight: 120,
       closedSeries: closedSeriesData,
       openSeries: openSeriesData,
       eventSeries: eventSeriesData,
+      showEventTable: true,
       showPoints: true,
       showLegendTable: true,
       showTips: true,
       unit: "%",
       yLabel: "Chaos",
       yLabelOffset: 35,
+      marginLeftEventTable: 10,
+      widthPercentageEventTable: 50,
     }}
   >
     {(args) => (
-      <div style={{ width: "30rem", height: "25rem" }}>
+      <div style={{ width: "40rem", height: "25rem" }}>
         <LineAreaGraph {...args} />
       </div>
     )}

--- a/src/lab/Graphs/LineAreaGraph/LineAreaGraph.stories.mdx
+++ b/src/lab/Graphs/LineAreaGraph/LineAreaGraph.stories.mdx
@@ -26,7 +26,7 @@ in form of lines, area-closed under the graph and events.
       yLabel: "Chaos",
       yLabelOffset: 35,
       marginLeftEventTable: 10,
-      widthPercentageEventTable: 50,
+      widthPercentageEventTable: 40,
     }}
   >
     {(args) => (

--- a/src/lab/Graphs/LineAreaGraph/base.ts
+++ b/src/lab/Graphs/LineAreaGraph/base.ts
@@ -22,7 +22,7 @@ export interface EventMetric extends GraphMetric {
   data: Array<DateValue>;
 
   // Sub-data describing the specific event
-  subData?: Array<{ subDataName: string; value: string }>;
+  subData?: Array<{ subDataName: string; value: string; date: number }>;
 
   // Color of the metric in the graph and legends
   baseColor?: string;

--- a/src/lab/Graphs/LineAreaGraph/base.ts
+++ b/src/lab/Graphs/LineAreaGraph/base.ts
@@ -105,3 +105,6 @@ export interface LineAreaGraphChildProps
   // Height of the LineAreaGraph excluding the legendTable
   height?: number;
 }
+
+export type ToolTipDateValue = ToolTip<DateValue>;
+export type TooltipData = Array<ToolTipDateValue>;

--- a/src/lab/Graphs/LineAreaGraph/styles.ts
+++ b/src/lab/Graphs/LineAreaGraph/styles.ts
@@ -1,4 +1,5 @@
 import { makeStyles, Theme } from "@material-ui/core";
+import { defaultStyles } from "@visx/tooltip";
 
 interface StyleProps {
   width: number;
@@ -81,14 +82,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     pointerEvents: "none",
   },
   tooltipMetric: {
+    ...defaultStyles,
     zIndex: 3,
+    margin: "0.5rem",
     marginTop: "1rem",
-    marginLeft: "3rem",
-    padding: "0.5rem",
+    marginLeft: "3.2rem",
+    padding: "1rem",
     backgroundColor: `${theme.palette.cards.background} !important`,
   },
   tooltipDateStyles: {
+    ...defaultStyles,
     position: "relative",
+    transform: "translate(-25%,0%)",
     marginTop: "0.5rem",
     backgroundColor: `${theme.palette.graph.toolTip} !important`,
   },
@@ -105,7 +110,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tooltipBottomDate: {
     justifyContent: "space-between",
-    padding: "0.2rem",
+    padding: "0.1rem",
     color: theme.palette.text.secondary,
   },
   tooltipLabel: {

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -2,9 +2,6 @@ import { DateValue, GraphMetric } from "../../Graphs/LineAreaGraph";
 import { EventMetric } from "./base";
 
 const openSeriesData1: DateValue[] = [
-  { date: 1000, value: 20 },
-  { date: 2000, value: 30 },
-  { date: 3000, value: 35 },
   { date: 4000, value: 40 },
   { date: 5000, value: 50 },
   { date: 6000, value: 74 },
@@ -12,9 +9,6 @@ const openSeriesData1: DateValue[] = [
   { date: 8000, value: 10 },
 ];
 const closedSeriesData1: DateValue[] = [
-  { date: 1000, value: 40 },
-  { date: 2000, value: 10 },
-  { date: 3000, value: 55 },
   { date: 4000, value: 60 },
   { date: 5000, value: 20 },
   { date: 6000, value: -14 },
@@ -22,9 +16,6 @@ const closedSeriesData1: DateValue[] = [
   { date: 8000, value: 10 },
 ];
 const closedSeriesData2: DateValue[] = [
-  { date: 1000, value: 0 },
-  { date: 2000, value: 14 },
-  { date: 3000, value: 5 },
   { date: 4000, value: 30 },
   { date: 5000, value: 50 },
   { date: 6000, value: 54 },
@@ -40,6 +31,8 @@ const eventSeriesData1: DateValue[] = [
   { date: 7000, value: 0 },
 ];
 const eventSeriesData2: DateValue[] = [
+  { date: 0, value: 1 },
+  { date: 1000, value: 1 },
   { date: 2000, value: 0 },
   { date: 3000, value: 0 },
   { date: 4000, value: 0 },

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -58,9 +58,26 @@ const openSeriesData: Array<GraphMetric> = [
     data: openSeriesData1,
     baseColor: "teal",
   },
+  {
+    metricName: "teal-1",
+    data: openSeriesData1,
+    baseColor: "teal",
+  },
+  {
+    metricName: "teal-2",
+    data: openSeriesData1,
+    baseColor: "teal",
+  },
+  {
+    metricName: "teal-3",
+    data: openSeriesData1,
+    baseColor: "teal",
+  },
 ];
 const closedSeriesData: Array<GraphMetric> = [
-  { metricName: "orange", data: closedSeriesData1, baseColor: "orange" },
+  { metricName: "orange-1", data: closedSeriesData1, baseColor: "orange" },
+  { metricName: "orange-2", data: closedSeriesData1, baseColor: "orange" },
+  { metricName: "orange-3", data: closedSeriesData1, baseColor: "orange" },
   { metricName: "pink", data: closedSeriesData2, baseColor: "pink" },
 ];
 const eventSeriesData: Array<EventMetric> = [

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -62,26 +62,9 @@ const openSeriesData: Array<GraphMetric> = [
     data: openSeriesData1,
     baseColor: "teal",
   },
-  {
-    metricName: "teal-1",
-    data: openSeriesData1,
-    baseColor: "teal",
-  },
-  {
-    metricName: "teal-2",
-    data: openSeriesData1,
-    baseColor: "teal",
-  },
-  {
-    metricName: "teal-3",
-    data: openSeriesData1,
-    baseColor: "teal",
-  },
 ];
 const closedSeriesData: Array<GraphMetric> = [
-  { metricName: "orange-1", data: closedSeriesData1, baseColor: "orange" },
-  { metricName: "orange-2", data: closedSeriesData1, baseColor: "orange" },
-  { metricName: "orange-3", data: closedSeriesData1, baseColor: "orange" },
+  { metricName: "orange", data: closedSeriesData1, baseColor: "orange" },
   { metricName: "pink", data: closedSeriesData2, baseColor: "pink" },
 ];
 const eventSeriesData: Array<EventMetric> = [
@@ -102,10 +85,10 @@ const eventSeriesData: Array<EventMetric> = [
     subData: [
       { subDataName: "subData-1-1", value: "1-1", date: 5000 },
       { subDataName: "subData-1-2", value: "1-2", date: 5000 },
-      { subDataName: "subData-1-3", value: "1-3", date: 11000 },
-      { subDataName: "subData-1-4", value: "1-4", date: 11000 },
-      { subDataName: "subData-1-5", value: "1-5", date: 11000 },
-      { subDataName: "subData-1-6", value: "1-6", date: 11000 },
+      { subDataName: "subData-2-1", value: "2-1", date: 11000 },
+      { subDataName: "subData-2-2", value: "2-2", date: 11000 },
+      { subDataName: "subData-2-3", value: "2-3", date: 11000 },
+      { subDataName: "subData-2-4", value: "2-4", date: 11000 },
     ],
     baseColor: "blue",
   },

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -40,8 +40,6 @@ const eventSeriesData1: DateValue[] = [
   { date: 7000, value: 0 },
 ];
 const eventSeriesData2: DateValue[] = [
-  { date: 0, value: 0 },
-  { date: 1000, value: 0 },
   { date: 2000, value: 0 },
   { date: 3000, value: 0 },
   { date: 4000, value: 0 },

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -46,6 +46,11 @@ const eventSeriesData2: DateValue[] = [
   { date: 7000, value: 1 },
   { date: 8000, value: 1 },
   { date: 9000, value: 0 },
+  { date: 10000, value: 0 },
+  { date: 11000, value: 1 },
+  { date: 12000, value: 1 },
+  { date: 13000, value: 1 },
+  { date: 14000, value: 0 },
 ];
 const openSeriesData: Array<GraphMetric> = [
   {
@@ -63,10 +68,10 @@ const eventSeriesData: Array<EventMetric> = [
     metricName: "chaos-pod-delete-",
     data: eventSeriesData1,
     subData: [
-      { subDataName: "subData-0-1", value: "0-1" },
-      { subDataName: "subData-0-2", value: "0-2" },
-      { subDataName: "subData-0-3", value: "0-3" },
-      { subDataName: "subData-0-4", value: "0-4" },
+      { subDataName: "subData-0-1", value: "0-1", date: 3000 },
+      { subDataName: "subData-0-2", value: "0-2", date: 3000 },
+      { subDataName: "subData-0-3", value: "0-3", date: 3000 },
+      { subDataName: "subData-0-4", value: "0-4", date: 3000 },
     ],
     baseColor: "red",
   },
@@ -74,8 +79,8 @@ const eventSeriesData: Array<EventMetric> = [
     metricName: "chaos-network-pod",
     data: eventSeriesData2,
     subData: [
-      { subDataName: "subData-1-1", value: "1-1" },
-      { subDataName: "subData-1-2", value: "1-2" },
+      { subDataName: "subData-1-1", value: "1-1", date: 5000 },
+      { subDataName: "subData-1-2", value: "1-2", date: 5000 },
     ],
     baseColor: "blue",
   },

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -32,6 +32,7 @@ const closedSeriesData2: DateValue[] = [
   { date: 8000, value: 30 },
 ];
 const eventSeriesData1: DateValue[] = [
+  { date: 2000, value: 0 },
   { date: 3000, value: 1 },
   { date: 4000, value: 1 },
   { date: 5000, value: 1 },
@@ -39,6 +40,9 @@ const eventSeriesData1: DateValue[] = [
   { date: 7000, value: 0 },
 ];
 const eventSeriesData2: DateValue[] = [
+  { date: 0, value: 0 },
+  { date: 1000, value: 0 },
+  { date: 2000, value: 0 },
   { date: 3000, value: 0 },
   { date: 4000, value: 0 },
   { date: 5000, value: 1 },
@@ -98,6 +102,10 @@ const eventSeriesData: Array<EventMetric> = [
     subData: [
       { subDataName: "subData-1-1", value: "1-1", date: 5000 },
       { subDataName: "subData-1-2", value: "1-2", date: 5000 },
+      { subDataName: "subData-1-3", value: "1-3", date: 11000 },
+      { subDataName: "subData-1-4", value: "1-4", date: 11000 },
+      { subDataName: "subData-1-5", value: "1-5", date: 11000 },
+      { subDataName: "subData-1-6", value: "1-6", date: 11000 },
     ],
     baseColor: "blue",
   },

--- a/src/lab/Graphs/LineAreaGraph/utils.ts
+++ b/src/lab/Graphs/LineAreaGraph/utils.ts
@@ -1,0 +1,43 @@
+import { bisector } from "d3-array";
+import { DateValue } from ".";
+import { ToolTipDateValue } from "./base";
+
+// Accessor functions
+const getDateNum = (d: DateValue) => {
+  if (d) {
+    if (typeof d.date === "number") {
+      return new Date(d.date);
+    } else return new Date(parseInt(d.date, 10));
+  } else {
+    return new Date(0);
+  }
+};
+
+const getValueNum = (d: DateValue) => {
+  if (d) {
+    if (typeof d.value === "number") {
+      return d.value;
+    } else return parseInt(d.value, 10);
+  } else {
+    return NaN;
+  }
+};
+
+const getValueStr = (d: DateValue) => {
+  if (d) {
+    if (typeof d.value === "number") {
+      return d.value.toFixed(2).toString();
+    } else return d.value;
+  } else {
+    return "";
+  }
+};
+
+// Bisectors
+const bisectDate = bisector<DateValue, Date>((d) => new Date(getDateNum(d)))
+  .left;
+const bisectorValue = bisector<ToolTipDateValue, number>((d) =>
+  getValueNum(d.data)
+).left;
+
+export { getDateNum, getValueNum, getValueStr, bisectDate, bisectorValue };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3474,9 +3474,9 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.2.tgz#1396e27f208ed56dd5638ab5a251edeb1c91d402"
-  integrity sha512-V0HGxJd0PiDF0ecHYIesTOqfd1gJguwQUOYfMfAWnRsWQEXfc5ifbUFhD3Wjc+O+y7VAqL+g07prq9gHQ/JOZQ==
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.3.tgz#81f1b07003b329f000b7912e59a24f52392867b6"
+  integrity sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4571,9 +4571,9 @@ class-utils@^0.3.5:
     static-extend "^0.1.1"
 
 classnames@^2.2.5:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.0.tgz#19524334bad47ccd99793936b67f9be0860fe835"
+  integrity sha512-UUf/S3eeczXBjHPpSnrZ1ZyxH3KmLW8nVYFUWIZA/dixYMIQr7l94yYKxaAkmPk7HO9dlT6gFqAPZC02tTdfQw==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -5123,9 +5123,9 @@ css-tree@1.0.0-alpha.37:
     source-map "^0.6.1"
 
 css-tree@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
-  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
@@ -5745,9 +5745,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.649:
-  version "1.3.703"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.703.tgz#6d9b9a75c42a40775f5930329e642b22b227317f"
-  integrity sha512-SVBVhNB+4zPL+rvtWLw7PZQkw/Eqj1HQZs22xtcqW36+xoifzEOEEDEpkxSMfB6RFeSIOcG00w6z5mSqLr1Y6w==
+  version "1.3.704"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz#894205a237cbe0097d63da8f6d19e605dd13ab51"
+  integrity sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA==
 
 element-resize-detector@^1.2.2:
   version "1.2.2"
@@ -8980,9 +8980,9 @@ lint-staged@^10.4.0:
     stringify-object "^3.3.0"
 
 listr2@^3.2.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.4.3.tgz#543bcf849d5ffc70602708b69d2daac73f751699"
-  integrity sha512-wZmkzNiuinOfwrGqAwTCcPw6aKQGTAMGXwG5xeU1WpDjJNeBA35jGBeWxR3OF+R6Yl5Y3dRG+3vE8t6PDcSNHA==
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.4.4.tgz#5bb5e0107cc9a8787dcfb5d302c88cbddcdba248"
+  integrity sha512-okQwtieCHDX5erlxcEn2xwNfVQhV+/YiD+U0v+6DQamXnknE7mc6B5fopHl96v1PuZjTpaoChctf96PB6K4XRg==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
@@ -8990,7 +8990,7 @@ listr2@^3.2.2:
     indent-string "^4.0.0"
     log-update "^4.0.0"
     p-map "^4.0.0"
-    rxjs "^6.6.6"
+    rxjs "^6.6.7"
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
@@ -9372,9 +9372,9 @@ media-typer@0.3.0:
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
 memfs@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.0.tgz#f9438e622b5acd1daa8a4ae160c496fdd1325b26"
-  integrity sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.1.tgz#12301801a14eb3daa9f7491aa0ff09ffec519dd0"
+  integrity sha512-Y5vcpQzWTime4fBTr/fEnxXUxEYUgKbDlty1WX0gaa4ae14I6KmvK1S8HtXOX0elKAE6ENZJctkGtbTFYcRIUw==
   dependencies:
     fs-monkey "1.0.1"
 
@@ -11036,10 +11036,18 @@ promise.series@^0.2.0:
   resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
   integrity sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=
 
-prompts@2.4.0, prompts@^2.0.1, prompts@^2.4.0:
+prompts@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
   integrity sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
+prompts@^2.0.1, prompts@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
+  integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
@@ -12254,7 +12262,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.6.0, rxjs@^6.6.6:
+rxjs@^6.6.0, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -13697,9 +13705,9 @@ unified-args@^8.0.0:
     unified-engine "^8.0.0"
 
 unified-engine@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-8.0.0.tgz#e3996ff6eaecc6ca3408af92b70e25691192d17d"
-  integrity sha512-vLUezxCnjzz+ya4pYouRQVMT8k82Rk4fIj406UidRnSFJdGXFaQyQklAnalsQHJrLqAlaYPkXPUa1upfVSHGCA==
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-8.1.0.tgz#a846e11705fb8589d1250cd27500b56021d8a3e2"
+  integrity sha512-ptXTWUf9HZ2L9xto7tre+hSdSN7M9S0rypUpMAcFhiDYjrXLrND4If+8AZOtPFySKI/Zhfxf7GVAR34BqixDUA==
   dependencies:
     concat-stream "^2.0.0"
     debug "^4.0.0"


### PR DESCRIPTION
1. Tooltip bounds added: now the tooltip will be flipped to the left side if the space on the right of the pointer is inadequate.
2. The date and metric div of the tooltip are now two separate tooltip. When the user moves out of the graph  svgto the any Legend Table the metric tooltip is hidden but the date and line marker remains. When the user mover out of the graph div then date and line marker is also hidden
3. subData shown in the chaos metric info table or Event table will be filtered as per the time stamp corresponding to the current hovering event span
4. Litmus-ui updated to 1.1.1
