### PR TITLE
Color augmentation added for lineAreaGraph, dayjs advance format and tooltip handler fix

### DIFF
--- a/src/lab/Graphs/LineAreaGraph/ColorsAugmentation.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ColorsAugmentation.tsx
@@ -1,0 +1,46 @@
+import { useTheme } from "@material-ui/core";
+import React from "react";
+import { GraphMetric, LineAreaGraphChildProps } from "./base";
+import { ComputationGraph } from "./ComputationGraph";
+
+const settingAugmentedColors = (
+  series: GraphMetric[] | undefined,
+  colorArray: string[]
+): GraphMetric[] | undefined => {
+  let elementColor: string;
+  return series?.map((linedata: GraphMetric, index) => {
+    elementColor = linedata.baseColor ?? colorArray[index % colorArray.length];
+    return {
+      metricName: linedata.metricName,
+      data: linedata.data,
+      baseColor: elementColor,
+    };
+  });
+};
+
+const ColorAugmentation: React.FC<LineAreaGraphChildProps> = ({
+  closedSeries,
+  openSeries,
+  eventSeries,
+  ...rest
+}) => {
+  const { palette } = useTheme();
+
+  const augmentedColorClosedSeries: GraphMetric[] =
+    settingAugmentedColors(closedSeries, palette.graph.area) ?? [];
+  const augmentedColorOpenSeries: GraphMetric[] =
+    settingAugmentedColors(openSeries, palette.graph.line) ?? [];
+  const augmentedColorEventSeries: GraphMetric[] =
+    settingAugmentedColors(eventSeries, [palette.error.main]) ?? [];
+
+  return (
+    <ComputationGraph
+      closedSeries={augmentedColorClosedSeries}
+      openSeries={augmentedColorOpenSeries}
+      eventSeries={augmentedColorEventSeries}
+      {...rest}
+    />
+  );
+};
+
+export { ColorAugmentation };

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -12,6 +12,7 @@ import {
 } from "@visx/visx";
 import { extent, max, min } from "d3-array";
 import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
 import React, { useCallback, useMemo, useState } from "react";
 import { LegendData } from "../LegendTable";
 import { LegendTable } from "../LegendTable/LegendTable";
@@ -58,7 +59,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
   height = 200,
   margin = {
     top: 20,
-    left: 30,
+    left: 60,
     bottom: 20,
     right: 10,
   },
@@ -84,6 +85,9 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
   const [dataRender, setAutoRender] = useState(true);
   // Use for showing the tooltip when showMultiTooltip is disabled
   const [mouseY, setMouseY] = useState(0);
+
+  // More format options for Dayjs
+  dayjs.extend(advancedFormat);
 
   //  ToolTip Data
   const {

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -13,6 +13,8 @@ import {
 import { extent, max, min } from "d3-array";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
+import isoWeek from "dayjs/plugin/isoWeek";
+import weekOfYear from "dayjs/plugin/weekOfYear";
 import React, { useCallback, useMemo, useState } from "react";
 import { LegendData } from "../LegendTable";
 import { LegendTable } from "../LegendTable/LegendTable";
@@ -33,8 +35,8 @@ import {
   getValueStr,
 } from "./utils";
 
-let dd1: DateValue;
-let dd0: DateValue;
+let dd1: DateValue | undefined;
+let dd0: DateValue | undefined;
 let i: number;
 let j: number;
 let indexer: number;
@@ -88,6 +90,8 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
 
   // More format options for Dayjs
   dayjs.extend(advancedFormat);
+  dayjs.extend(isoWeek);
+  dayjs.extend(weekOfYear);
 
   //  ToolTip Data
   const {
@@ -284,7 +288,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         if (showMultiToolTip) {
           setMouseY(y);
         }
-        const y0 = valueScale.invert(y);
+        const y0: number = valueScale.invert(y);
         if (firstMouseEnterGraph === false) {
           setMouseEnterGraph(true);
         }
@@ -292,8 +296,8 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         if (filteredClosedSeries) {
           for (j = 0; j < filteredClosedSeries.length; j++) {
             indexer = bisectDate(filteredClosedSeries[i].data, x0, 1);
-            dd0 = filteredClosedSeries[j].data[indexer - 1];
-            dd1 = filteredClosedSeries[j].data[indexer];
+            dd0 = filteredClosedSeries[j]?.data[indexer - 1] ?? undefined;
+            dd1 = filteredClosedSeries[j]?.data[indexer] ?? undefined;
 
             if (dd1) {
               pointerDataSelection[i] =
@@ -316,8 +320,8 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         if (filteredOpenSeries) {
           for (j = 0; j < filteredOpenSeries.length; j++) {
             indexer = bisectDate(filteredOpenSeries[j].data, x0, 1);
-            dd0 = filteredOpenSeries[j].data[indexer - 1];
-            dd1 = filteredOpenSeries[j].data[indexer];
+            dd0 = filteredOpenSeries[j]?.data[indexer - 1] ?? undefined;
+            dd1 = filteredOpenSeries[j]?.data[indexer] ?? undefined;
 
             if (dd1) {
               pointerDataSelection[i] =
@@ -359,24 +363,25 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         if (!showMultiToolTip) {
           let index0 = 0;
           let closestValue: number | undefined;
-
-          index0 = bisectorValue(pointerDataSelection, y0);
-          dd0 = pointerDataSelection[index0].data;
-          dd1 = pointerDataSelection[index0 - 1].data;
-          if (dd1 && dd0) {
-            closestValue =
-              Math.abs(y0.valueOf() - getValueNum(dd0)) >
-              Math.abs(y0.valueOf() - getValueNum(dd1))
-                ? getValueNum(dd1)
-                : getValueNum(dd0);
-          } else if (dd1 && !dd0) {
-            closestValue = getValueNum(dd1);
-          } else if (dd0 && !dd1) {
-            closestValue = getValueNum(dd0);
+          if (pointerDataSelection && pointerDataSelection[0]) {
+            index0 = bisectorValue(pointerDataSelection, y0, 1);
+            dd0 = pointerDataSelection[index0]?.data ?? undefined;
+            dd1 = pointerDataSelection[index0 - 1]?.data ?? undefined;
+            if (dd1 && dd0) {
+              closestValue =
+                Math.abs(y0.valueOf() - getValueNum(dd0)) >
+                Math.abs(y0.valueOf() - getValueNum(dd1))
+                  ? getValueNum(dd1)
+                  : getValueNum(dd0);
+            } else if (dd1 && !dd0) {
+              closestValue = getValueNum(dd1);
+            } else if (dd0 && !dd1) {
+              closestValue = getValueNum(dd0);
+            }
+            pointerDataSelection = pointerDataSelection.filter(
+              (lineData) => closestValue && lineData.data.value === closestValue
+            );
           }
-          pointerDataSelection = pointerDataSelection.filter(
-            (lineData) => closestValue && lineData.data.value === closestValue
-          );
         }
         toolTipPointLength = pointerDataSelection.length;
         let singleEventToolTip: ToolTipDateValue;
@@ -387,8 +392,8 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         if (filteredEventSeries) {
           for (j = 0; j < filteredEventSeries.length; j++) {
             indexer = bisectDate(filteredEventSeries[j].data, x0, 1);
-            dd0 = filteredEventSeries[j].data[indexer - 1];
-            dd1 = filteredEventSeries[j].data[indexer];
+            dd0 = filteredEventSeries[j]?.data[indexer - 1] ?? undefined;
+            dd1 = filteredEventSeries[j]?.data[indexer] ?? undefined;
             if (
               dd1 &&
               toolTipPointLength > 0 &&

--- a/src/lab/Graphs/LineAreaGraph/FilteredLineAreaGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/FilteredLineAreaGraph.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { GraphMetric, LineAreaGraphChildProps } from "./base";
-import { ComputationGraph } from "./ComputationGraph";
+import { ColorAugmentation } from "./ColorsAugmentation";
 
 // filterUndefinedData performs type checking and
 const filterUndefinedData = (
@@ -21,17 +21,9 @@ const filterUndefinedData = (
     : data;
 
 const FilteredLineAreaGraph: React.FC<LineAreaGraphChildProps> = ({
-  compact = false,
   closedSeries,
   openSeries,
   eventSeries,
-  height = 200,
-  margin = {
-    top: 20,
-    left: 100,
-    bottom: 20,
-    right: 20,
-  },
   ...rest
 }) => {
   let augmentEventSeries: Array<GraphMetric> | undefined =
@@ -68,17 +60,12 @@ const FilteredLineAreaGraph: React.FC<LineAreaGraphChildProps> = ({
   const augmentOpenSeries: Array<GraphMetric> =
     filterUndefinedData(openSeries) ?? [];
   return (
-    <div>
-      <ComputationGraph
-        closedSeries={augmentClosedSeries}
-        openSeries={augmentOpenSeries}
-        eventSeries={augmentEventSeries}
-        height={height}
-        margin={margin}
-        compact={compact}
-        {...rest}
-      />
-    </div>
+    <ColorAugmentation
+      closedSeries={augmentClosedSeries}
+      openSeries={augmentOpenSeries}
+      eventSeries={augmentEventSeries}
+      {...rest}
+    />
   );
 };
 

--- a/src/lab/Graphs/LineAreaGraph/LineAreaGraph.stories.mdx
+++ b/src/lab/Graphs/LineAreaGraph/LineAreaGraph.stories.mdx
@@ -19,7 +19,7 @@ in form of lines, area-closed under the graph and events.
       openSeries: openSeriesData,
       eventSeries: eventSeriesData,
       showEventTable: true,
-      showMultiToolTip: true,
+      showMultiToolTip: false,
       showPoints: true,
       showLegendTable: false,
       showTips: true,
@@ -28,6 +28,7 @@ in form of lines, area-closed under the graph and events.
       yLabelOffset: 35,
       marginLeftEventTable: 10,
       widthPercentageEventTable: 40,
+      xAxistimeFormat: "hh:mm:ss Do MMM",
     }}
   >
     {(args) => (

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -58,11 +58,11 @@ const openSeriesData: Array<GraphMetric> = [
 ];
 const closedSeriesData: Array<GraphMetric> = [
   { metricName: "orange", data: closedSeriesData1, baseColor: "orange" },
-  { metricName: "pink", data: closedSeriesData2, baseColor: "pink" },
+  { metricName: "noColorAssigned-1", data: closedSeriesData2 },
 ];
 const eventSeriesData: Array<EventMetric> = [
   {
-    metricName: "chaos-pod-delete-",
+    metricName: "chaos-pod-delete-no-color",
     data: eventSeriesData1,
     subData: [
       { subDataName: "subData-0-1", value: "0-1", date: 3000 },
@@ -70,7 +70,6 @@ const eventSeriesData: Array<EventMetric> = [
       { subDataName: "subData-0-3", value: "0-3", date: 3000 },
       { subDataName: "subData-0-4", value: "0-4", date: 3000 },
     ],
-    baseColor: "red",
   },
   {
     metricName: "chaos-network-pod",


### PR DESCRIPTION
1. baseColor props if not defined then the colors will be taken from `palette.graph` and the corresponding graph series type.
2. advance plugin for dayjs added  
3. Tool tip handler error fix
![Screenshot from 2021-06-01 12-00-00](https://user-images.githubusercontent.com/18084015/120276941-030bf200-c2d1-11eb-9a2f-02dac281fc7e.png)

Signed-off-by: Ritik Srivastava <ritik@chaosnative.com>
