### PR TITLE
pass fail bar fix and open series added to xAxis calc in stackBar

### DIFF
--- a/src/lab/Graphs/PassFailBar/PassFailBar.tsx
+++ b/src/lab/Graphs/PassFailBar/PassFailBar.tsx
@@ -7,6 +7,9 @@ export interface PassFailBarProps {
   // Pass percentage value as number
   passPercentage: number;
 
+  // Fail percentage value as number
+  failPercentage?: number;
+
   // Optional className for overriding the styles
   className?: string;
 }
@@ -22,13 +25,14 @@ const PassFailBarChild = ({
   width,
   height,
   passPercentage,
+  failPercentage,
   className,
 }: PassFailBarChildProps) => {
   const classes = useStyles({
     width,
     height,
     pass: `${passPercentage ?? 0}%`,
-    fail: `${100 - passPercentage ?? 0}%`,
+    fail: `${failPercentage ?? 100 - passPercentage ?? 0}%`,
   });
 
   return width < 10 ? null : (
@@ -45,7 +49,7 @@ const PassFailBarChild = ({
         <Typography
           variant="h6"
           className={`${classes.failText} ${classes.text}`}
-        >{`${100 - passPercentage ?? 0}%`}</Typography>
+        >{`${failPercentage ?? 100 - passPercentage ?? 0}%`}</Typography>
       </div>
     </div>
   );

--- a/src/lab/Graphs/PassFailBar/styles.ts
+++ b/src/lab/Graphs/PassFailBar/styles.ts
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   singleBar: (props: StyleProps) => ({
     marginRight: theme.spacing(1),
     borderRadius: "0.3rem 0 0 0.3rem",
-    height: props.height / 2 - theme.spacing(1),
+    height: props.height / 2 - theme.spacing(1.18),
     minWidth: "0.1rem",
     marginTop: theme.spacing(1),
   }),

--- a/src/lab/Graphs/StackBars/PlotStackBar.tsx
+++ b/src/lab/Graphs/StackBars/PlotStackBar.tsx
@@ -128,6 +128,11 @@ const PlotStackBar = ({
   const xMax = width - margin.left - margin.right;
   const yMax = height - margin.top - margin.bottom;
   const localInitialxAxisDate = initialxAxisDate ?? barSeries[0].date ?? 0;
+  const openSeriesDates = openSeries
+    ? openSeries.data
+        .map((element) => element.date)
+        .concat(localInitialxAxisDate)
+    : [localInitialxAxisDate];
   const xScale = useMemo(
     () =>
       scaleTime<number>({
@@ -136,7 +141,7 @@ const PlotStackBar = ({
           new Date(
             Math.min(
               ...barSeries.map((element) => element.date),
-              localInitialxAxisDate
+              ...openSeriesDates
             )
           ),
           new Date(Math.max(...barSeries.map((element) => element.date))),

--- a/src/lab/Graphs/StackBars/StackBar.stories.mdx
+++ b/src/lab/Graphs/StackBars/StackBar.stories.mdx
@@ -20,7 +20,7 @@ of the bar here is 0-100.
       unit: "%",
       yLabel: "Chaos",
       yLabelOffset: 35,
-      initalxAxisDate: 0,
+      initialxAxisDate: 0,
       handleBarClick: testHandleBarClick,
     }}
   >

--- a/src/lab/Graphs/StackBars/testData.ts
+++ b/src/lab/Graphs/StackBars/testData.ts
@@ -4,6 +4,7 @@ const testHandleBarClick = (barData: any) => console.log("barId", barData);
 const openSeries: LineMetricSeries = {
   metricName: "probe success",
   data: [
+    { date: 0, value: 10 },
     { date: 10, value: 10 },
     { date: 20, value: 10 },
     { date: 30, value: 1 },


### PR DESCRIPTION
1. Pass fail bar: `failPercentage` prop has been added which may be used to override the calculation of failPercentage shown to the user which was earlier dependent on `passPercentage` only.
2. StackBar: `openSeries` or the line Data has been also added to the computation of the x-axis. Earlier only bar data was considered.
Signed-off-by: Ritik Srivastava <ritik@chaosnative.com>