### PR TITLE
Changed the rollup config to split the components into individual chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "litmus-ui",
   "license": "Apache-2.0",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "private": false,
   "description": "Component Library for LitmusChaos",
   "author": "LitmusChaos Authors",
@@ -49,9 +49,6 @@
       "pre-push": "yarn test"
     }
   },
-  "main": "lib.cjs.js",
-  "module": "lib.esm.js",
-  "types": "index.d.ts",
   "dependencies": {
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.9.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,34 +5,29 @@ import { terser } from "rollup-plugin-terser";
 import typescript from "rollup-plugin-typescript2";
 import pkg from "./package.json";
 
-const globals = {
-  react: "React",
-  "react-dom": "ReactDOM",
-  "@material-ui/core": "MaterialUI",
-  "@material-ui/lab": "MaterialUILab",
-  "@visx/visx": "Visx",
-};
-
 export default {
   input: "./src/index.ts",
   external: [
     ...Object.keys(pkg.dependencies),
+    ...Object.keys(pkg.peerDependencies),
     ...Object.keys(pkg.devDependencies),
+    "dayjs/plugin/advancedFormat",
+    "dayjs/plugin/isoWeek",
+    "dayjs/plugin/weekOfYear",
   ],
   output: [
     {
-      file: `./dist/${pkg.main}`,
+      dir: "dist",
       format: "cjs",
-      globals,
       sourcemap: true,
     },
     {
-      file: `./dist/${pkg.module}`,
+      dir: "dist",
       format: "es",
-      globals,
       sourcemap: true,
     },
   ],
+  preserveModules: true,
   plugins: [
     commonjs(),
     postcss({

--- a/src/core/Input/AutocompleteChipInput/AutocompleteChipInput.tsx
+++ b/src/core/Input/AutocompleteChipInput/AutocompleteChipInput.tsx
@@ -1,5 +1,4 @@
-import Checkbox from "@material-ui/core/Checkbox";
-import TextField from "@material-ui/core/TextField";
+import { Checkbox, TextField } from "@material-ui/core";
 import CheckBoxIcon from "@material-ui/icons/CheckBox";
 import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
 import { Autocomplete } from "@material-ui/lab";

--- a/src/lab/Graphs/StackBars/PlotStackBar.tsx
+++ b/src/lab/Graphs/StackBars/PlotStackBar.tsx
@@ -1,16 +1,19 @@
 import { useTheme } from "@material-ui/core";
-import { AxisBottom } from "@visx/axis";
-import { Grid } from "@visx/grid";
-import { Group } from "@visx/group";
-import { scaleBand, scaleLinear, scaleOrdinal, scaleTime } from "@visx/scale";
-import { BarStack } from "@visx/shape";
-import { useTooltip } from "@visx/tooltip";
 import {
+  AxisBottom,
   AxisLeft,
+  BarStack,
   curveMonotoneX,
+  Grid,
+  Group,
   LinePath,
   localPoint,
+  scaleBand,
+  scaleLinear,
+  scaleOrdinal,
+  scaleTime,
   Tooltip,
+  useTooltip,
 } from "@visx/visx";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {


### PR DESCRIPTION
Changed the rollup config to split the components into individual chunks and removed some warnings during the build

Signed-off-by: arkajyotiMukherjee <arko@chaosnative.com>