### PR TITLE
Filter url fix

### DIFF
--- a/src/lab/Graphs/LegendTable/LegendTable.tsx
+++ b/src/lab/Graphs/LegendTable/LegendTable.tsx
@@ -56,7 +56,9 @@ const LegendTable: React.FC<LegendTableProps> = ({ data, heading }) => {
                             style={{ background: row.baseColor }}
                           />
                         )}
-                        <Typography>{element}</Typography>
+                        <Typography className={classes.metricNameText}>
+                          {element}
+                        </Typography>
                       </TableCell>
                     )) ||
                     (index !== 0 && (

--- a/src/lab/Graphs/LegendTable/style.ts
+++ b/src/lab/Graphs/LegendTable/style.ts
@@ -5,6 +5,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: "flex",
     width: "100%",
     height: "100%",
+    position: "relative",
     backgroundColor: theme.palette.background.paper,
     overflowY: "auto",
     "&::-webkit-scrollbar": {
@@ -57,8 +58,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignContent: "flex-start",
   },
   tableFont: {
-    wordWrap: "break-word",
+    width: "inherit",
     whiteSpace: "initial",
+    overflowWrap: "break-word",
     alignContent: "flex-start",
     color: theme.palette.text.primary,
   },
@@ -66,8 +68,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: "1rem",
     height: "0.2rem",
     alignSelf: "baseline",
-    marginRight: "0.5em",
+    position: "absolute",
     marginTop: "0.5rem",
+  },
+  metricNameText: {
+    marginLeft: "1.5rem",
   },
 }));
 

--- a/src/lab/Graphs/LegendTable/style.ts
+++ b/src/lab/Graphs/LegendTable/style.ts
@@ -73,6 +73,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   metricNameText: {
     marginLeft: "1.5rem",
+    wordBreak: "break-word",
   },
 }));
 

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -9,6 +9,7 @@ import {
   scaleLinear,
   scaleTime,
   Tooltip,
+  TooltipWithBounds,
   useTooltip,
 } from "@visx/visx";
 import { extent, max, min } from "d3-array";
@@ -1066,6 +1067,8 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
       )}
       {tooltipDataDate && showTips && tooltipDataDate[0] && (
         <Tooltip
+          // key added as per visx guideline
+          key={Math.random()}
           top={yMax}
           left={tooltipLeftDate}
           className={classes.tooltipDateStyles}
@@ -1078,15 +1081,14 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
         </Tooltip>
       )}
       {tooltipData && showTips && tooltipData[0] && (
-        <Tooltip
-          left={tooltipLeft}
+        <TooltipWithBounds
+          // key added as per visx guideline
+          key={Math.random()}
+          left={tooltipLeft + margin.left}
           top={showMultiToolTip ? mouseY : tooltipTop}
           // Hardcoded value for tooltip
           // will be removed later
-          className={`${classes.tooltipMetric} ${
-            width - margin.left - margin.right - tooltipLeft < 160
-              ? classes.tooltipMetricLeft
-              : classes.tooltipMetricRight
+          className={`${classes.tooltipMetric}
           }`}
         >
           {tooltipData.map((linedata, index) => (
@@ -1105,7 +1107,7 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
               </div>
             </div>
           ))}
-        </Tooltip>
+        </TooltipWithBounds>
       )}
 
       {showLegendTable && showEventTable && (

--- a/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/ComputationGraph.tsx
@@ -95,7 +95,6 @@ const ComputationGraph: React.FC<LineAreaGraphChildProps> = ({
   // bounds
   const xMax = Math.max(width - margin.left - margin.right, 0);
   const yMax = Math.max(topChartHeight, 0);
-
   const classes = useStyles({
     width,
     height,

--- a/src/lab/Graphs/LineAreaGraph/PlotLineAreaGraph.tsx
+++ b/src/lab/Graphs/LineAreaGraph/PlotLineAreaGraph.tsx
@@ -18,6 +18,7 @@ import {
 import dayjs from "dayjs";
 import React from "react";
 import { DateValue, StrictColorGraphMetric } from "./base";
+import { removeSpecialChar } from "./utils";
 
 // Accessors
 const getDateNum = (d: DateValue) =>
@@ -155,7 +156,9 @@ const PlotLineAreaGraph: React.FC<AreaChartProps> = ({
         closedSeries.map((linedata: StrictColorGraphMetric, index) => (
           <Group key={`closedSeriesGroup-${linedata.metricName}-${index}`}>
             <LinearGradient
-              id={`${linedata.metricName}-${linedata.baseColor}-linearGragient`}
+              id={`${removeSpecialChar(linedata.metricName)}-${
+                linedata.baseColor
+              }-linearGragient`}
               from={linedata.baseColor}
               to={linedata.baseColor}
               fromOpacity={0.5}
@@ -169,7 +172,9 @@ const PlotLineAreaGraph: React.FC<AreaChartProps> = ({
               yScale={yScale}
               strokeWidth={2}
               stroke={linedata.baseColor}
-              fill={`url(#${linedata.metricName}-${linedata.baseColor}-linearGragient)`}
+              fill={`url(#${removeSpecialChar(linedata.metricName)}-${
+                linedata.baseColor
+              }-linearGragient)`}
               curve={curveMonotoneX}
             />
 

--- a/src/lab/Graphs/LineAreaGraph/styles.ts
+++ b/src/lab/Graphs/LineAreaGraph/styles.ts
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: "1rem",
     padding: "1rem",
     backgroundColor: `${theme.palette.cards.background} !important`,
-    transition: "all 0.3s ease-out",
+    minWidth: "10rem !important",
   },
   tooltipMetricLeft: {
     transform: "translate(-90%,0)",

--- a/src/lab/Graphs/LineAreaGraph/styles.ts
+++ b/src/lab/Graphs/LineAreaGraph/styles.ts
@@ -95,6 +95,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingLeft: "1.5rem",
       maxWidth: "20rem",
       lineHeight: "1rem",
+      wordBreak: "break-word",
     },
   },
   tooltipBottomDate: {

--- a/src/lab/Graphs/LineAreaGraph/styles.ts
+++ b/src/lab/Graphs/LineAreaGraph/styles.ts
@@ -68,10 +68,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: "1rem",
     padding: "1rem",
     backgroundColor: `${theme.palette.cards.background} !important`,
-    "-o-transition": "all 0.3s ease-out",
-    "-ms-transition": "all 0.3s ease-out",
-    "-moz-transition": "all 0.3s ease-out",
-    "-webkit-transition": " all 0.3s ease-out",
     transition: "all 0.3s ease-out",
   },
   tooltipMetricLeft: {

--- a/src/lab/Graphs/LineAreaGraph/styles.ts
+++ b/src/lab/Graphs/LineAreaGraph/styles.ts
@@ -68,6 +68,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: "1rem",
     padding: "1rem",
     backgroundColor: `${theme.palette.cards.background} !important`,
+    "-o-transition": "all 0.3s ease-out",
+    "-ms-transition": "all 0.3s ease-out",
+    "-moz-transition": "all 0.3s ease-out",
+    "-webkit-transition": " all 0.3s ease-out",
+    transition: "all 0.3s ease-out",
   },
   tooltipMetricLeft: {
     transform: "translate(-90%,0)",

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -58,8 +58,17 @@ const openSeriesData: Array<GraphMetric> = [
   },
 ];
 const closedSeriesData: Array<GraphMetric> = [
-  { metricName: "orange", data: closedSeriesData1, baseColor: "orange" },
-  { metricName: "noColorAssigned-1", data: closedSeriesData2 },
+  // Orange series has space in between. It tests the url encoding in for coloring.
+  {
+    metricName: "orange series with whiteSpaces",
+    data: closedSeriesData1,
+    baseColor: "orange",
+  },
+  {
+    metricName:
+      "no-Color-has-been-assigened-to-this-series-Also-the-name-of-this-series-is-very-long-without-any-white-space",
+    data: closedSeriesData2,
+  },
 ];
 const eventSeriesData: Array<GraphMetric> = [
   {
@@ -67,7 +76,12 @@ const eventSeriesData: Array<GraphMetric> = [
     data: eventSeriesData1,
     subData: [
       { subDataName: "subData-0-1", value: "0-1", date: 3000 },
-      { subDataName: "subData-0-2", value: "0-2", date: 3000 },
+      {
+        subDataName:
+          "subData-0-2-Long-sub-data-without-any-whiteSpace-to-test-wrapping",
+        value: "0-2",
+        date: 3000,
+      },
       { subDataName: "subData-0-3", value: "0-3", date: 3000 },
       { subDataName: "subData-0-4", value: "0-4", date: 3000 },
     ],

--- a/src/lab/Graphs/LineAreaGraph/testData.ts
+++ b/src/lab/Graphs/LineAreaGraph/testData.ts
@@ -66,7 +66,7 @@ const closedSeriesData: Array<GraphMetric> = [
   },
   {
     metricName:
-      "no-Color-has-been-assigened-to-this-series-Also-the-name-of-this-series-is-very-long-without-any-white-space",
+      "noColorHasBeenAssigenedToThisSeriesAlsoTheNameOfThisSeriesIsVeryLongWithoutAnyWhiteSpace",
     data: closedSeriesData2,
   },
 ];
@@ -78,7 +78,7 @@ const eventSeriesData: Array<GraphMetric> = [
       { subDataName: "subData-0-1", value: "0-1", date: 3000 },
       {
         subDataName:
-          "subData-0-2-Long-sub-data-without-any-whiteSpace-to-test-wrapping",
+          "subData-0-2-Long-sub-data-without-any-whiteSpace-to-test-wrapping-in-subData",
         value: "0-2",
         date: 3000,
       },

--- a/src/lab/Graphs/LineAreaGraph/utils.ts
+++ b/src/lab/Graphs/LineAreaGraph/utils.ts
@@ -2,6 +2,9 @@ import { bisector } from "d3-array";
 import { DateValue } from ".";
 import { ToolTipDateValue } from "./base";
 
+// List of special characters
+const specialCharList = ["$", "&", "%", ",", "/", ":", ";", "=", "?", "@"];
+
 // Accessor functions
 const getDateNum = (d: DateValue) => {
   if (d) {
@@ -49,6 +52,16 @@ const bisectorValue = bisector<ToolTipDateValue, number>((d) =>
   getValueNum(d.data)
 ).left;
 
+// For removing special characters from the string
+const removeSpecialChar = (value: string): string => {
+  let cleanString = value;
+  cleanString = cleanString.replace(/\s/g, "-");
+  specialCharList.forEach(
+    (element) => (cleanString = cleanString.replace(element, "-"))
+  );
+  return cleanString;
+};
+
 export {
   getDateNum,
   getValueNum,
@@ -56,4 +69,5 @@ export {
   getSum,
   bisectDate,
   bisectorValue,
+  removeSpecialChar,
 };


### PR DESCRIPTION
1. Area under the curve graphs were rendering black in cases where the name of the metric had any special character (these special characters add a different meaning when used in the URL). This issue has been fixed. All these special characters from the metric name will be overridden first ( metric name shown to the user will remain unchanged) and then be used in the URL encoding.

2. For long metric names which did not have any white space were overflowing. This issue has been fixed.