### PR TITLE
Added Litmus-ui bundle enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "litmus-ui",
   "license": "Apache-2.0",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": false,
   "description": "Component Library for LitmusChaos",
   "author": "LitmusChaos Authors",
@@ -9,6 +9,9 @@
   "bugs": {
     "url": "https://github.com/litmuschaos/litmus-ui/issues"
   },
+  "sideEffects": false,
+  "main": "./index.js",
+  "module": "./esm/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/litmuschaos/litmus-ui.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,9 +4,12 @@ import postcss from "rollup-plugin-postcss";
 import { terser } from "rollup-plugin-terser";
 import typescript from "rollup-plugin-typescript2";
 import pkg from "./package.json";
+import getAllEntryPoints from "./scripts/inputs";
+
+const input = getAllEntryPoints("./src");
 
 export default {
-  input: "./src/index.ts",
+  input,
   external: [
     ...Object.keys(pkg.dependencies),
     ...Object.keys(pkg.peerDependencies),
@@ -22,8 +25,8 @@ export default {
       sourcemap: true,
     },
     {
-      dir: "dist",
-      format: "es",
+      dir: "dist/esm",
+      format: "esm",
       sourcemap: true,
     },
   ],

--- a/scripts/inputs.js
+++ b/scripts/inputs.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+const getAllEntryPoints = function (dirPath, arrayOfFiles) {
+  let files = fs.readdirSync(dirPath);
+  arrayOfFiles = arrayOfFiles || [];
+
+  files.forEach(function (file) {
+    if (fs.statSync(dirPath + "/" + file).isDirectory()) {
+      arrayOfFiles = getAllEntryPoints(dirPath + "/" + file, arrayOfFiles);
+    } else {
+      if (file === "index.ts") {
+        arrayOfFiles.push(path.join(dirPath, "/", file));
+      }
+    }
+  });
+
+  return arrayOfFiles;
+};
+
+export default getAllEntryPoints;

--- a/src/core/Button/ButtonFilled/index.ts
+++ b/src/core/Button/ButtonFilled/index.ts
@@ -1,1 +1,2 @@
 export * from "./ButtonFilled";
+export { ButtonFilled as default } from "./ButtonFilled";

--- a/src/core/Button/ButtonGroup/index.ts
+++ b/src/core/Button/ButtonGroup/index.ts
@@ -1,1 +1,2 @@
 export * from "./ButtonGroup";
+export { ButtonGroup as default } from "./ButtonGroup";

--- a/src/core/Button/ButtonOutlined/index.ts
+++ b/src/core/Button/ButtonOutlined/index.ts
@@ -1,1 +1,2 @@
 export * from "./ButtonOutlined";
+export { ButtonOutlined as default } from "./ButtonOutlined";

--- a/src/core/Button/TextButton/index.ts
+++ b/src/core/Button/TextButton/index.ts
@@ -1,1 +1,2 @@
 export * from "./TextButton";
+export { TextButton as default } from "./TextButton";

--- a/src/core/Button/ToggleButton/index.ts
+++ b/src/core/Button/ToggleButton/index.ts
@@ -1,1 +1,2 @@
 export * from "./ToggleButton";
+export { ToggleButton as default } from "./ToggleButton";

--- a/src/core/Drawer/index.ts
+++ b/src/core/Drawer/index.ts
@@ -1,1 +1,2 @@
 export * from "./Drawer";
+export { Drawer as default } from "./Drawer";

--- a/src/core/Input/AutocompleteChipInput/index.ts
+++ b/src/core/Input/AutocompleteChipInput/index.ts
@@ -1,1 +1,2 @@
 export * from "./AutocompleteChipInput";
+export { AutocompleteChipInput as default } from "./AutocompleteChipInput";

--- a/src/core/Input/EditableText/index.ts
+++ b/src/core/Input/EditableText/index.ts
@@ -1,1 +1,2 @@
 export * from "./EditableText";
+export { EditableText as default } from "./EditableText";

--- a/src/core/Input/InputField/index.ts
+++ b/src/core/Input/InputField/index.ts
@@ -1,1 +1,2 @@
 export * from "./InputField";
+export { InputField as default } from "./InputField";

--- a/src/core/LitmusCard/index.ts
+++ b/src/core/LitmusCard/index.ts
@@ -1,1 +1,2 @@
 export * from "./LitmusCard";
+export { LitmusCard as default } from "./LitmusCard";

--- a/src/core/Modal/index.ts
+++ b/src/core/Modal/index.ts
@@ -1,1 +1,2 @@
 export * from "./Modal";
+export { Modal as default } from "./Modal";

--- a/src/core/Pills/BasicPills/index.ts
+++ b/src/core/Pills/BasicPills/index.ts
@@ -1,1 +1,2 @@
 export * from "./BasicPills";
+export { Pills as default } from "./BasicPills";

--- a/src/core/Pills/LightPills/index.ts
+++ b/src/core/Pills/LightPills/index.ts
@@ -1,1 +1,2 @@
 export * from "./LightPills";
+export { LightPills as default } from "./LightPills";

--- a/src/core/Pills/OutlinedPills/index.ts
+++ b/src/core/Pills/OutlinedPills/index.ts
@@ -1,1 +1,2 @@
 export * from "./OutlinedPills";
+export { OutlinedPills as default } from "./OutlinedPills";

--- a/src/core/ProgressBar/index.ts
+++ b/src/core/ProgressBar/index.ts
@@ -1,1 +1,2 @@
 export * from "./ProgressBar";
+export { ProgressBar as default } from "./ProgressBar";

--- a/src/core/QuickActionCard/index.ts
+++ b/src/core/QuickActionCard/index.ts
@@ -1,2 +1,3 @@
 export { QuickActionCardProps } from "./base";
 export * from "./QuickActionCard";
+export { QuickActionCard as default } from "./QuickActionCard";

--- a/src/core/RadioButton/index.ts
+++ b/src/core/RadioButton/index.ts
@@ -1,1 +1,2 @@
 export * from "./RadioButton";
+export { RadioButton as default } from "./RadioButton";

--- a/src/core/Search/index.ts
+++ b/src/core/Search/index.ts
@@ -1,1 +1,2 @@
 export * from "./Search";
+export { Search as default } from "./Search";

--- a/src/core/Snackbar/index.ts
+++ b/src/core/Snackbar/index.ts
@@ -1,1 +1,2 @@
 export * from "./Snackbar";
+export { Snackbar as default } from "./Snackbar";

--- a/src/core/Typography/index.ts
+++ b/src/core/Typography/index.ts
@@ -1,1 +1,2 @@
 export * from "./Typography";
+export { Typography as default } from "./Typography";

--- a/src/lab/Graphs/CalendarHeatmap/index.ts
+++ b/src/lab/Graphs/CalendarHeatmap/index.ts
@@ -1,2 +1,3 @@
 export type { CalendarHeatmapTooltipProps, WeekData } from "./base";
 export * from "./CalendarHeatmap";
+export { CalendarHeatmap as default } from "./CalendarHeatmap";

--- a/src/lab/Graphs/LegendTable/index.ts
+++ b/src/lab/Graphs/LegendTable/index.ts
@@ -1,1 +1,2 @@
 export * from "./LegendTable";
+export { LegendTable as default } from "./LegendTable";

--- a/src/lab/Graphs/LineAreaGraph/index.ts
+++ b/src/lab/Graphs/LineAreaGraph/index.ts
@@ -5,3 +5,4 @@ export type {
   StrictColorGraphMetric,
 } from "./base";
 export * from "./LineAreaGraph";
+export { LineAreaGraph as default } from "./LineAreaGraph";

--- a/src/lab/Graphs/PassFailBar/index.ts
+++ b/src/lab/Graphs/PassFailBar/index.ts
@@ -1,1 +1,2 @@
 export * from "./PassFailBar";
+export { PassFailBar as default } from "./PassFailBar";

--- a/src/lab/Graphs/RadialGraphs/RadialChart/index.ts
+++ b/src/lab/Graphs/RadialGraphs/RadialChart/index.ts
@@ -1,1 +1,2 @@
 export * from "./RadialChart";
+export { RadialChart as default } from "./RadialChart";

--- a/src/lab/Graphs/RadialGraphs/RadialProgressChart/index.ts
+++ b/src/lab/Graphs/RadialGraphs/RadialProgressChart/index.ts
@@ -1,1 +1,2 @@
 export * from "./RadialProgressChart";
+export { RadialProgressChart as default } from "./RadialProgressChart";

--- a/src/lab/Graphs/StackBars/index.ts
+++ b/src/lab/Graphs/StackBars/index.ts
@@ -1,2 +1,3 @@
 export type { BarDateValue, LineMetricSeries, StackBarMetric } from "./base";
 export * from "./StackBar";
+export { StackBar as default } from "./StackBar";


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@chaosnative.com>

**This PR will add enhancements for Litmus-ui Bundle -** 
- Added a JS script to find entrypoints for all components. These will help in providing absolute paths for importing components.
- Added default exports at components level.
For e.g. Now, ButtonFilled component can be imported like below given ways -
```
   - import {ButtonFilled} from "litmus-ui";
   - import {ButtonFilled} from "litmus-ui/core";
   - import {ButtonFilled} from "litmus-ui/core/Button";
   - import {ButtonFilled} from "litmus-ui/core/Button/ButtonFilled";
   - import ButtonFilled from "litmus-ui/core/Button/ButtonFilled"; 
```
 
- Fixed ESM module configuration in rollup.config & package.json for modern bundlers.